### PR TITLE
表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.7.3"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-i18n"
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.10.1)
       devise (>= 4.8.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.3)
     globalid (0.5.2)
@@ -244,6 +246,7 @@ DEPENDENCIES
   byebug
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -3,7 +3,7 @@ ja:
     text: &genre
       genre:
         invisible: '非表示'
-        basic: ' Basic'
+        basic: 'Basic'
         git: 'Git'
         ruby: 'Ruby'
         rails: 'Ruby on Rails'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,11 @@
+ja:
+  enums:
+    text: &genre
+      genre:
+        invisible: '非表示'
+        basic: ' Basic'
+        git: 'Git'
+        ruby: 'Ruby'
+        rails: 'Ruby on Rails'
+        php: 'PHP'
+    movie: *genre


### PR DESCRIPTION
close #10 

## 実装内容

- `gem 'enum_help'`の追加
- `config/locales/enums.ja.yml`の追加
  - `Texts`,`Movies`テーブルの`genre`の表示名を設定

## 確認内容

- 以下を実行し，教材データが入っていることを確認

```bash
rails c
# Railsコンソール起動後
Text.genres_i18n
#=> {"invisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}
Movie.genres_i18n
#=> {"invisible"=>"非表示", "basic"=>"Basic", "git"=>"Git", "ruby"=>"Ruby", "rails"=>"Ruby on Rails", "php"=>"PHP"}
```

## 参考資料（必要があれば）

- [【やんばるエキスパート教材】列挙型（enum）とセレクトボックス](https://www.yanbaru-code.com/texts/351)
- [【Qiita】.ymlファイルの使い方まとめ。&, *, <<の使い方](https://qiita.com/shizen-shin/items/f9eab69fa3dbfd5532cc)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行