### PR TITLE
ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,13 +2,14 @@
  *= require_tree .
  *= require_self
  */
- 
- @import "bootstrap/scss/bootstrap";
+
+@import 'bootstrap/scss/bootstrap';
 
 /* 全体 */
 .base-container {
   margin: 0 auto;
   padding: 1rem;
+  padding-top: 69px;
 }
 /* max-width */
 .mw-sm {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,45 @@
-<% if user_signed_in? %>
-  <%# ログイン時 %>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-<% else %>
-  <%# 非ログイン時 %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end %>
+<nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top">
+  <%= link_to image_tag('yanbaru_expert_logo.png'), root_path, class: 'navbar-brand' %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Ruby
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item" %>
+        </div>
+      </li>
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          PHP
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <%= link_to "PHPテキスト教材", texts_path(genre: "php"), class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
+        </div>
+      </li>
+      <% if user_signed_in? %>
+        <%# ログイン時 %>
+        <li class="nav-item">
+          <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "ログアウト", destroy_user_session_path, class: "nav-item nav-link active", method: :delete, data: { confirm: "ログアウトしますか？" } %>
+        </li>
+      <% else %>
+        <%# 非ログイン時 %>
+        <li class="nav-item">
+          <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+        </li>
+      </ul>
+    <% end %>
+  </div>
+</nav>


### PR DESCRIPTION
close #11 

## 実装内容

- ナビバーの実装
  - Bootstrapを使ってナビバーやハンバーガーメニューを作成
  - ロゴをクリックするとrootパスに飛ぶリンクを追加
  - Ruby、PHPそれぞれの教材へのリンクを追加

## 確認内容

- ログイン時・ログアウト時の表示が上記画像と同じような形式になっているかを確認
- ヘッダーが上に固定されていることを確認（ブラウザの縦幅を短めにしてスクロール）
- 768px 未満で「ハンバーガーメニュー」に変化すること
- 「ドロップダウン」「ハンバーガーメニュー」が問題なく動作すること
- リンクが正常に機能していること

## 参考資料（必要があれば）

- ナビバー・ハンバーガーメニューの実装
  - [【公式】Bootstrap（Navbar）](https://getbootstrap.jp/docs/4.5/components/navbar/)
  - [メッセージ投稿アプリ（その3・Bootstrap）](https://www.yanbaru-code.com/texts/271)
  - [Bootstrapのハンバーガーメニューをカスタマイズする方法！](https://qumeru.com/magazine/562)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
