### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,5 @@
+.body-size {
+  margin: 0 auto;
+  max-width: 376px;
+  height: 370px;
+}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,15 +1,5 @@
-.text-page-title {
-  font-size: 2.5rem;
-}
-
-.row {
-  margin: 0 -15px;
-  .card-box {
-    padding: 0 15px;
-    .card {
-      margin: 0 auto;
-      max-width: 376px;
-      height: 370px;
-    }
-  }
+.body-size {
+  margin: 0 auto;
+  max-width: 376px;
+  height: 370px;
 }

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,5 +1,15 @@
-.body-size {
-  margin: 0 auto;
-  max-width: 376px;
-  height: 370px;
+.text-page-title {
+  font-size: 2.5rem;
+}
+
+.row {
+  margin: 0 -15px;
+  .card-box {
+    padding: 0 15px;
+    .card {
+      margin: 0 auto;
+      max-width: 376px;
+      height: 370px;
+    }
+  }
 }

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,7 @@
 class TextsController < ApplicationController
-  def index; end
+  def index
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+  end
 
   def show; end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,5 @@
 class Text < ApplicationRecord
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,14 @@
+<div class="card-box col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header p-0">
+      <img class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" >
+    </div>
+    <div class="card-body text-dark">
+      <div class="read-through-box mb-1">
+        <a href="#" class="btn btn-block btn-secondary">読破済みにする</a>
+      </div>
+      <p class="card-title mt-3 mb-3"><%= text.title %></p>
+      <p class="card-text">【<%= text.genre_i18n %>】</p>
+    </div>
+  </div>
+</div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,5 +1,5 @@
 <div class="card-box col-12 col-md-6 col-lg-4">
-  <div class="card border-dark mb-3">
+  <div class="card body-size border-dark mb-3">
     <div class="card-header p-0">
       <img class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" >
     </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,0 +1,8 @@
+<h1 class="text-center mt-2 mb-4">
+  Ruby/Rails
+  <br class="d-sm-none">
+  テキスト教材
+</h1>
+<div class="row">
+  <%= render partial: "text", collection: @texts %>
+</div>


### PR DESCRIPTION
close #13

## 実装内容

- テキスト教材一覧ページ
  - レンダリングで表示
  - レスポンシブ対応

## 確認内容

画像のようにレスポンシブ対応ができているかどうかを確認
ブラウザの横幅次第でカードの横幅が長くなりすぎていないか確認
PHPのテキスト教材が表示されていないことを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行