### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.genre_list(params[:genre])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_title
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -21,5 +21,4 @@ class Movie < ApplicationRecord
       where(genre: Movie::RAILS_GENRE_LIST)
     end
   end
-
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,6 @@
 class Movie < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php]
   validates :genre, presence: true
   validates :title, presence: true
   validates :url, presence: true
@@ -12,4 +13,13 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  def self.genre_list(genre)
+    if genre == "php"
+      where(genre: Movie::PHP_GENRE_LIST)
+    else
+      where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
+
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h1 class="text-center mt-2 mb-4">
-    Ruby/Rails 動画
+    <%= movie_title %>
   </h1>
   <div class="row">
     <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #18 

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
  - `PHP動画教材` のリンクをクリックした際のクエリパラメータ `?genre=php` を利用
  - モデルにクラスメソッドを作成して対応できるとなおよいでしょう

- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする
  - `app/helpers/application_helper.rb` にメソッドを作成して対応できるとなおよいでしょう

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ `?genre=php` を `php` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行